### PR TITLE
Add pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Pillow
+matplotlib
+opencv-python
+pydub
+moviepy
+ffmpeg
+spacy
+textblob
+praw
+tinydb


### PR DESCRIPTION
I used this when hosting the bot myself, and I think others trying to do the same can benefit from this.
You can now install the requirements with:

    pip3 install -r requirements.txt

Rather than needing to find and install all the dependencies individually.