### PR TITLE
Optimise Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
 FROM python:3.7-slim-buster
-COPY . /app
 WORKDIR /app
-RUN apt-get update
-RUN apt-get install ffmpeg libsm6 libxext6 -y
-RUN pip install -r requirements.txt
-RUN python -m spacy download en_core_web_sm
+
+COPY requirements.txt .
+RUN apt-get update && \
+  apt-get install ffmpeg libsm6 libxext6 -y && \
+  pip install -r requirements.txt && \
+  python -m spacy download en_core_web_sm && \
+  apt-get clean && \
+  rm -rf ~/.cache/pip/*
+
+COPY . .
+
 ENV streamable_username ${streamable_username}
 ENV streamable_password ${streamable_password}
 ENV reddit_client_id ${reddit_client_id}
 ENV reddit_client_secret ${reddit_client_secret}
 ENV reddit_refresh_token ${reddit_refresh_token}
+
 CMD python ./bot_streamable.py


### PR DESCRIPTION
* Moved package acquisition to be first and cache-busted when `requirements.txt` changes. Should speed up repeat builds by leveraging Docker's build cache.
* Cleared apt and pip caches after installing packages. Shaved ~200MB off the image size.