### PR TITLE
Add spacy model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ spacy
 textblob
 praw
 tinydb
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz


### PR DESCRIPTION
Project won't work if spacy doesn't find en_core_web_sm.

Although spacy models are usually downloaded using `python -m spacy download en_core_web_sm`, they can also be downloaded using pip.
This way, adding it to requirements.txt would make the project work transparently for users without them needing to manually download said model