### PR TITLE
Importing correct ffmpeg library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ matplotlib
 opencv-python
 pydub
 moviepy
-ffmpeg
+ffmpeg-python
 spacy
 textblob
 praw


### PR DESCRIPTION
The use of "mmpeg" library was throwing `"AttributeError: module 'ffmpeg' has no attribute 'input'"`

That was due to the incorrect "ffmpeg" library being installed. It seems the intended library is in fact [ffmpeg-python](https://github.com/kkroening/ffmpeg-python).
More info in this issue: https://github.com/kkroening/ffmpeg-python/issues/174

EDIT: Thanks for the project, BTW ^^